### PR TITLE
Use `io::Write::write_all` in `encode`

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -21,7 +21,7 @@ where
     let mut num_bytes = 0;
     let mut write = |buf: &[u8]| {
         num_bytes += buf.len();
-        output.write(buf)
+        output.write_all(buf)
     };
 
     // Write the file header


### PR DESCRIPTION
`std::io::Write::write` can fail to write all the bytes in the given buffer to the receiver but still succeed with an `Ok`.

`std::io::Write::write_all` ensures the entire given buffer is written before it returns.

Calls to the `write` closure return `Result<usize, io::Error>`. The `usize` in the `Ok` variant is how many of the given bytes have been written. Since this value is not used, I think the intent is for the entire write to always succeed when getting back `Ok`, which is what `write_all` guarantees.